### PR TITLE
feat: Manual patch release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "codepipeline-s3-package",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,6 @@
     "test": "npm-run-all test:*",
     "test:code": "eslint .",
     "test:unit": "cross-env NODE_ENV=testing mocha tests/ --recursive --check-leaks",
-    "test_:audit": "audit-ci --high"
+    "test:audit": "audit-ci --high"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codepipeline-s3-package",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Provides ability to do AWS S3 source updates for AWS Codepipeline",
   "keywords": [
     "aws",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,6 @@
     "test": "npm-run-all test:*",
     "test:code": "eslint .",
     "test:unit": "cross-env NODE_ENV=testing mocha tests/ --recursive --check-leaks",
-    "test:audit": "audit-ci --high"
+    "test_:audit": "audit-ci --high"
   }
 }


### PR DESCRIPTION
Had to do manual patch release in order to circumvent the aws-sdk issue since there is no release pipeline for the package

```
Error: Cannot find module '/root/.npm/_npx/56/lib/node_modules/codepipeline-s3-package/node_modules/aws-sdk/scripts/check-node-version.js'
```

Also, had to disable npm audit for the release since it was giving errors (and rightfully so) but only the specific version has been tested to work. So disabled it for now, next release should do full npm update.